### PR TITLE
Compatibility with older versions of Graphviz

### DIFF
--- a/lib/dot.js
+++ b/lib/dot.js
@@ -40,15 +40,15 @@ function statsString(node, patterns) {
       value = formatTime(value);
     }
 
-    return ' ' + key + ' (' + value + ') \n';
+    return key + ' (' + value + ')';
   });
 
-  return result.join('');
+  return result.join('\\n');
 }
 
 module.exports = function dot(graph, options) {
   var out = 'digraph G {';
-  out += ' ratio = "auto"';
+  out += ' ratio = "auto"\n';
 
   var patterns = options && options.stats;
 
@@ -61,7 +61,7 @@ module.exports = function dot(graph, options) {
 
     out += ' ' + node._id;
     var annotation = node.id.name;
-    annotation = annotation.replace('(', '\n(');
+    annotation = annotation.replace(' (', '\\n(');
 
     var shape, style;
 
@@ -76,11 +76,11 @@ module.exports = function dot(graph, options) {
       style = 'solid';
     }
 
-    out += ' [shape=' + shape + ', style=' + style + ', colorscheme="rdylbu9", color=' + selfTimeColor(selfTime) +', label=" ' +
-       node._id + ' \n' +
-       annotation  + '\n' +
+    out += ' [shape=' + shape + ', style=' + style + ', colorscheme="rdylbu9", color=' + selfTimeColor(selfTime) +', label="' +
+       node._id + '\\n' +
+       annotation  + '\\n' +
        statsString(node, patterns) +
-       ' "]';
+       '"]';
 
     out += '\n';
 
@@ -88,7 +88,7 @@ module.exports = function dot(graph, options) {
       // such doubts
       // var level = node.level + byId[child].level;
       var level = graph.nodesById[childId].stats._broccoli_viz.level;
-      out += ' ' + childId + ' -> ' + node._id + '[penwidth=' + penWidth(level) + ' ] \n';
+      out += ' ' + childId + ' -> ' + node._id + ' [penwidth=' + penWidth(level) + ']\n';
     });
   });
   out += '}';

--- a/test/viz-test.js
+++ b/test/viz-test.js
@@ -30,43 +30,43 @@ describe('dot', function() {
   it('displays self and total time by default', function() {
     var result = dot(processGraph([a]));
 
-    assert.equal(result, 'digraph G { ratio = \"auto\" 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\" 1 \na\n time.self (40ms) \n time.total (40ms) \n \"]\n}');
+    assert.equal(result, 'digraph G { ratio = \"auto\"\n 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\"1\\na\\ntime.self (40ms)\\ntime.total (40ms)\"]\n}');
 
     result = dot(processGraph([a], { stats: null }));
 
-    assert.equal(result, 'digraph G { ratio = \"auto\" 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\" 1 \na\n time.self (40ms) \n time.total (40ms) \n \"]\n}');
+    assert.equal(result, 'digraph G { ratio = \"auto\"\n 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\"1\\na\\ntime.self (40ms)\\ntime.total (40ms)\"]\n}');
 
     result = dot(processGraph([a], { stats: undefined }));
 
-    assert.equal(result, 'digraph G { ratio = \"auto\" 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\" 1 \na\n time.self (40ms) \n time.total (40ms) \n \"]\n}');
+    assert.equal(result, 'digraph G { ratio = \"auto\"\n 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\"1\\na\\ntime.self (40ms)\\ntime.total (40ms)\"]\n}');
   });
 
   it('can display stats matching a glob', function() {
     var result = dot(processGraph([a]), { stats: ['time.self'] });
 
-    assert.equal(result, 'digraph G { ratio = \"auto\" 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\" 1 \na\n time.self (40ms) \n \"]\n}');
+    assert.equal(result, 'digraph G { ratio = \"auto\"\n 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\"1\\na\\ntime.self (40ms)\"]\n}');
 
     result = dot(processGraph([a]), { stats: ['fs.*.count'] });
 
-    assert.equal(result, 'digraph G { ratio = \"auto\" 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\" 1 \na\n fs.lstatSync.count (10) \n fs.openSync.count (2) \n \"]\n}');
+    assert.equal(result, 'digraph G { ratio = \"auto\"\n 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\"1\\na\\nfs.lstatSync.count (10)\\nfs.openSync.count (2)\"]\n}');
   });
 
   it('treats stats named time as nanoseconds', function() {
     result = dot(processGraph([a]), { stats: ['fs.lstatSync.*'] });
 
-    assert.equal(result, 'digraph G { ratio = \"auto\" 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\" 1 \na\n fs.lstatSync.count (10) \n fs.lstatSync.time (20ms) \n \"]\n}');
+    assert.equal(result, 'digraph G { ratio = \"auto\"\n 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\"1\\na\\nfs.lstatSync.count (10)\\nfs.lstatSync.time (20ms)\"]\n}');
   });
 
   it('aliases totalTime to time.total', function() {
     var result = dot(processGraph([a]), { stats: ['time.total'] });
 
-    assert.equal(result, 'digraph G { ratio = \"auto\" 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\" 1 \na\n time.total (40ms) \n \"]\n}');
+    assert.equal(result, 'digraph G { ratio = \"auto\"\n 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\"1\\na\\ntime.total (40ms)\"]\n}');
   });
 
   it('can display stats matching multiple globs', function() {
     var result = dot(processGraph([a]), { stats: ['time.*', 'fs.*.count'] });
 
-    assert.equal(result, 'digraph G { ratio = \"auto\" 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\" 1 \na\n time.self (40ms) \n time.total (40ms) \n fs.lstatSync.count (10) \n fs.openSync.count (2) \n \"]\n}');
+    assert.equal(result, 'digraph G { ratio = \"auto\"\n 1 [shape=box, style=solid, colorscheme=\"rdylbu9\", color=7, label=\"1\\na\\ntime.self (40ms)\\ntime.total (40ms)\\nfs.lstatSync.count (10)\\nfs.openSync.count (2)\"]\n}');
   });
 });
 


### PR DESCRIPTION
Currently, broccoli-viz produces output like the following:

    digraph G { ratio = "auto" 1 [shape=box, style=solid, colorscheme="rdylbu9", color=8, label=" 1 
    name 
    (with parenthetical)
     time.self (6ms) 
     time.total (11ms) 
     "]
     2 -> 1[penwidth=3 ] 
     2 [shape=box, style=solid, colorscheme="rdylbu9", color=9, label=" 2 
    another node
     time.self (4ms) 
     time.total (4ms) 
     "]
    }

However, older versions of Graphviz do not support bare newlines embedded in quoted strings, interpreting the string to end at EOL and the remainder of the text to be nodes.  Errors are produced when running `dot`:

    Warning: broccoli-viz.0-broken.dot:1: string ran past end of line
    Error: broccoli-viz.0-broken.dot:3: syntax error near line 3
    context:  >>> ( <<< with parenthetical)
    Warning: broccoli-viz.0-broken.dot:4: ambiguous "6ms" splits into two names: "6" and "ms"
    Warning: broccoli-viz.0-broken.dot:5: ambiguous "11ms" splits into two names: "11" and "ms"
    Warning: broccoli-viz.0-broken.dot:6: string ran past end of line
    Warning: broccoli-viz.0-broken.dot:8: string ran past end of line
    Warning: broccoli-viz.0-broken.dot:10: ambiguous "4ms" splits into two names: "4" and "ms"
    Warning: broccoli-viz.0-broken.dot:11: ambiguous "4ms" splits into two names: "4" and "ms"
    Warning: broccoli-viz.0-broken.dot:12: string ran past end of line

And the resulting graph is utterly useless:

![broccoli-viz 0](https://cloud.githubusercontent.com/assets/275142/23325961/663d929c-faae-11e6-8578-ed96fa44c163.png)

With this PR, newlines are encoded, producing output like the following:

    digraph G { ratio = "auto"
     1 [shape=box, style=solid, colorscheme="rdylbu9", color=8, label="1\nname\n(with parenthetical)\ntime.self (6ms)\ntime.total (11ms)"]
     2 -> 1[penwidth=3]
     2 [shape=box, style=solid, colorscheme="rdylbu9", color=9, label="2\nanother node\ntime.self (4ms)\ntime.total (4ms)"]
    }

No errors are produced by `dot` when processing this document and the resulting graph is again meaningful:

![broccoli-viz 0-fixed](https://cloud.githubusercontent.com/assets/275142/23326013/c5497724-faae-11e6-9dfb-53bd13c40c6f.png)

On newer versions of Graphviz, the encoded newlines continue to function as expected.  These changes were tested on Graphviz 2.26 (which is affected by the issue) and 2.38 (which is not).