### PR TITLE
Fix broken stats argument in the CLI

### DIFF
--- a/bin/broccoli-viz
+++ b/bin/broccoli-viz
@@ -32,5 +32,5 @@ if (patterns && !Array.isArray(patterns)) {
   patterns = [patterns];
 }
 
-console.log(viz.dot(viz.process(json.nodes, argv)));
+console.log(viz.dot(viz.process(json.nodes, argv), { stats: patterns }));
 


### PR DESCRIPTION
Looks like a regression created by commit `4f3a31bd43575eb00cc2eed1a075263470abd56a` (probably by a forced merge). That commit removed the `options` argument (which contained the stats filtering patterns) from the call to the `dot` function in the binary.